### PR TITLE
Fix iOS scroll overscroll showing white background

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,10 @@
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
+html {
+  background: var(--bg);
+}
+
 body {
   font-family: system-ui, sans-serif;
   font-size: 16px;


### PR DESCRIPTION
Added background color to html element to prevent iOS Safari's
rubber-banding effect from revealing white space above content
when scrolling down.