### PR TITLE
Add color-scheme property to fix iOS overscroll in both modes

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,5 @@
 :root {
+  color-scheme: light;
   --text: #111;
   --muted: #555;
   --link: #877267;
@@ -8,6 +9,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    color-scheme: dark;
     --text: #ddd;
     --muted: #888;
     --link: #a89388;


### PR DESCRIPTION
The color-scheme CSS property explicitly tells Safari which theme to use for UI elements like the overscroll area, ensuring light mode shows white and dark mode shows dark on overscroll.